### PR TITLE
MIT License issue and Require rpm-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.0.2
+VERSION=1.0.3
 NAME=njs2rpm
 RPMTOPDIR=`pwd`/rpmbuild
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ dist:
 	rm -f $(NAME)-$(VERSION).tar.gz;\
 	rm -rf $(NAME)-$(VERSION);\
 	mkdir $(NAME)-$(VERSION); \
-	tar -c --exclude ".svn" --exclude "$(NAME)-$(VERSION)" --exclude "rpmbuild" . | tar -x -C $(NAME)-$(VERSION);\
+	tar -c --exclude ".svn" --exclude "$(NAME)-$(VERSION)" --exclude "rpmbuild" --exclude ".git" . | tar -x -C $(NAME)-$(VERSION);\
 	tar -czvf $(NAME)-$(VERSION).tar.gz  $(NAME)-$(VERSION);\
 	rm -rf $(NAME)-$(VERSION)
 clean:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Examples:
 
 ## Syntax
 
-    NJS2RPM v1.0.2 - NodeJs module to RPM converter by Sergio Freire <sergio-s-freire@ptinovacao.pt>
+    NJS2RPM v1.0.3 - NodeJs module to RPM converter by Sergio Freire <sergio-s-freire@ptinovacao.pt>
      Usage: njs2rpm <name> <version> <release> <single|bundle> <spec|rpm> [template]
             name: NodeJS module name
             version: module version in X.Y.Z format

--- a/njs2rpm
+++ b/njs2rpm
@@ -147,7 +147,7 @@ LICENSE=$( echo "$JSONDESC"   | egrep -i '"license"\s*:' | cut -d ":" -f 2 |tr -
 if [ "$LICENSE" == "" ]
 then
  # try to guess the license
- LICENSE=$( echo "$LICENSEDESC" | head -n 1 | egrep -E -i -o "Apache\s+\w|ASL\s+\w+(.\w)?|MIT|L?GPL\s+\w+(.\w)?|BSD" )
+ LICENSE=$( echo "$LICENSEDESC" | head -n 1 | egrep -E -i -o "Apache\s+\w|ASL\s+\w+(.\w)?|MIT|L?GPL\s+\w+(.\w)?|BSD" | head -n 1 )
  if [ "$LICENSE" == "" ]
  then
   # unable to guess the license.. well quit and assume "unknown"

--- a/njs2rpm
+++ b/njs2rpm
@@ -4,7 +4,7 @@
 # Copyright Sergio Freire <sergio-s-freire@ptinovacao.pt>
 # More info at https://github.com/sfreire/n2r
 
-MYVERSION=1.0.2
+MYVERSION=1.0.3
 echo -e "NJS2RPM v$MYVERSION - NodeJs module to RPM converter by Sergio Freire <sergio-s-freire@ptinovacao.pt>"
 
 SCRIPTNAME=$(basename $0)

--- a/njs2rpm.spec
+++ b/njs2rpm.spec
@@ -17,7 +17,7 @@ Source: %{name}-%{version}.tar.gz
 URL: https://github.com/sfreire/njs2rpm
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildArch: noarch
-Requires: redhat-rpm-config, tar, coreutils, wget, nodejs-packaging, nodejs-devel, npm
+Requires: redhat-rpm-config, tar, coreutils, wget, nodejs-packaging, nodejs-devel, npm, rpm-build
 
 %description 
 NJS2RPM - convert NodeJS modules to RPM packages (by Sergio Freire)

--- a/njs2rpm.spec
+++ b/njs2rpm.spec
@@ -8,7 +8,7 @@
 
 
 Name    : njs2rpm
-Version : 1.0.2
+Version : 1.0.3
 Release : 1.%{disttype}%{distnum}
 Summary: NJS2RPM - convert NodeJS module to RPM
 Group: Development/Libraries
@@ -57,6 +57,9 @@ rm -rf %{buildroot}
 %{_docdir}/LICENSE
 
 %changelog
+* Mon May 19 2014 JM Goncalves <joao-m-goncalves@telecom.pt> - 1.0.3-1
+- added rpm-build to Requires
+- fixed egrep multi-match in license retrieval (caused problems with MIT License)
 * Tue Jan 21 2014 Sergio Freire <sergio-s-freire@ptinovacao.pt> - 1.0.2-1
 - fixed issue #1 (problem with user defined _topdir)
 * Thu Nov  8 2013 Sergio Freire <sergio-s-freire@ptinovacao.pt> - 1.0.1-1


### PR DESCRIPTION
Change log:
1. Added rpm-build to Requires (prevents "rpmbuild: No such file or directory").
2. Fixed egrep multi-match in license retrieval (caused problems with the MIT License case). The fix is not very elegant (a head on the egrep result) but it works. The egrep -m option doesn't work because it refers to lines. Maybe you can use that to skip the first head?
   
   -m NUM, --max-count=NUM
               Stop reading a file after NUM matching lines.
